### PR TITLE
nbformat 5.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,12 +44,6 @@ test:
     - testpath
   imports:
     - nbformat
-  downstreams:
-    - anaconda-client
-    # CI fails on win64 and python 3.10
-    - conda-repo-cli  # [not win64 and py==310]
-    - ipywidgets
-    - nootebook
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,36 +10,48 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jupyter-trust = nbformat.sign:TrustNotebookApp.launch_instance
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.5
-    - ipython_genutils
-    - traitlets >=4.1
+    - python
     - jsonschema >=2.4,!=2.5.0
     - jupyter_core
+    - python-fastjsonschema
+    - traitlets >=4.1
 
 test:
+  source_files:
+    - tests
   commands:
     - pip check
-    - jupyter-trust -h
+    - jupyter trust --version
+    - jupyter-trust --help
+    - pytest -vv --cov nbformat --cov-report term-missing:skip-covered --no-cov-on-fail --cov-fail-under 79
   requires:
     - pip
+    - pytest
+    - pytest-cov
+    - testpath
   imports:
     - nbformat
 
 about:
-  home: http://jupyter.org
+  home: https://jupyter.org
   license: BSD-3-Clause
+  license_family: BSD
   summary: The Jupyter Notebook format
   license_file: COPYING.md
+  doc_url: https://nbformat.readthedocs.io
+  dev_url: https://github.com/jupyter/nbformat 
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,8 @@ test:
     - nbformat
   downstreams:
     - anaconda-client
-    - conda-repo-cli
+    # CI fails on win64 and python 3.10
+    - conda-repo-cli  # [not win64 and py==310]
     - ipywidgets
     - nootebook
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.1.3" %}
+{% set version = "5.3.0" %}
 
 package:
   name: nbformat
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/nbformat/nbformat-{{ version }}.tar.gz
-  sha256: b516788ad70771c6250977c1374fcca6edebe6126fd2adb5a69aa5c2356fd1c8
+  sha256: fcc5ab8cb74e20b19570b5be809e2dba9b82836fd2761a89066ad43394ba29f5
 
 build:
   number: 0
@@ -19,11 +19,12 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=60.0
     - wheel
   run:
     - python
-    - jsonschema >=2.4,!=2.5.0
+
+    - jsonschema >=2.6
     - jupyter_core
     - python-fastjsonschema
     - traitlets >=4.1
@@ -43,6 +44,11 @@ test:
     - testpath
   imports:
     - nbformat
+  downstreams:
+    - anaconda-client
+    - conda-repo-cli
+    - ipywidgets
+    - nootebook
 
 about:
   home: https://jupyter.org


### PR DESCRIPTION
Changelog: https://github.com/jupyter/nbformat/blob/5.3.0/docs/changelog.rstc
License: https://github.com/jupyter/nbformat/blob/5.3.0/COPYING.md
Requirements: 
- https://github.com/jupyter/nbformat/blob/5.3.0/pyproject.toml
- https://github.com/jupyter/nbformat/blob/5.3.0/setup.py 

Actions:
1. Remove `noarch: python`
2. Skip `py<37`
3. Fix `python` in host and run
4. Add missing packages: `setuptools >=60.0` and `wheel`
5. Update `jsonschema >=2.6,` add `python-fastjsonschema`, remove `ipython_genutils` in `run`
6. Update tests: add `source_files` and p`ytest`
7. Add `license_family`
8. Add dev and doc urls