### PR TITLE
nbformat 5.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nbformat" %}
-{% set version = "5.5.0" %}
+{% set version = "5.7.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/nbformat-{{ version }}.tar.gz
-  sha256: 9ebe30e6c3b3e5b47d39ff0a3897a1acf523d2bfafcb4e2d04cdb70f8a66c507
+  sha256: 1d4760c15c1a04269ef5caf375be8b98dd2f696e5eb9e603ec2bf091f9b0d3f3
 
 build:
   number: 0


### PR DESCRIPTION
**Jira ticket:** [PKG-157](https://anaconda.atlassian.net/browse/PKG-157) (nbformat-5.4.0)

**The upstream data:**
Github releases:  https://github.com/jupyter/nbformat/releases
[Diff between the latest and previous upstream releases](https://github.com/jupyter/nbformat/compare/5.5.0...5.7.0)
Changelog: https://github.com/jupyter/nbformat/blob/main/CHANGELOG.md
Requirements:
 * pyproject.toml:  https://github.com/jupyter/nbformat/blob/5.7.0/pyproject.toml

**_Actions:_**

1. 
**_Notes:_**
 * 
**Package's statistics**
<details>

 * Priority C | effort: easy | Category: anaconda | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 5.7.0
 * Release on PyPi:
    * version: 5.7.0
    * date: 2022-10-10T13:12:17
* [PyPi history](https://pypi.org/project/nbformat/#history)
 * Popularity: 
    * 3 months downloads: 1612398.0
    * All time:  10934159 downloads -  nbformat  5.7.0  The Jupyter Notebook format  

</details>

**Links:**
<details>

* [The upstream URL](https://github.com/jupyter/nbformat/tree/5.7.0)
* [dev_url](https://github.com/jupyter/nbformat)
* [doc_url](https://github.com/jupyter/nbformat)
* [Bug tracker](https://github.com/conda-forge/nbformat-feedstock/issues)
* [Anaconda recipe feedstock](https://github.com/AnacondaRecipes/nbformat-feedstock)
* [Update branch: _5.7.0_](https://github.com/AnacondaRecipes/nbformat-feedstock/tree/5.7.0)
* [PyPi](https://pypi.org/project/nbformat)
* [conda-forge recipe](https://github.com/conda-forge/nbformat-feedstock/blob/master/recipe/meta.yaml)
* [Diff between upstream conda-forge **main** and aggreagate **feature** branch](https://github.com/conda-forge/nbformat-feedstock/compare/main...AnacondaRecipes:5.7.0#files_bucket)
* [Diff between origin aggregate **master** and aggreagate **feature** branch](https://github.com/AnacondaRecipes/nbformat-feedstock/compare/master...AnacondaRecipes:5.7.0#files_bucket)
* [The last merged PRs](https://github.com/AnacondaRecipes/nbformat-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

</details>

**Anaconda Linter:**

<details>

The following problems have been found:

WARNING: /aggregate/nbformat-feedstock/recipe/meta.yaml:57: missing_description: The recipe is missing a description
WARNING: /aggregate/nbformat-feedstock/recipe/meta.yaml:57: missing_license_url: The recipe is missing a license_url
WARNING: /aggregate/nbformat-feedstock/recipe/meta.yaml:57: missing_doc_source_url: The recipe is missing a doc_source_url
Warnings were found

</details>

**Crender checks:**

<details>
5.3.0:
- Build section might be actual noarch

</details>


**Other checks:**

<details>

1. - [x] https://github.com/jupyter/nbformat/tree/5.7.0 exists
2. - [x] https://jupyter.org exists
3. - [ ] Check the pinnings
4. - [x] https://github.com/jupyter/nbformat/blob/main/CHANGELOG.md exists
5. - [ ] Additional research
    https://github.com/conda-forge/nbformat-feedstock/issues
    200
6. - [x] `dev_url` exists
    https://github.com/jupyter/nbformat
7. - [ ] `doc_url` error:
    https://nbformat.readthedocs.io
    302
8. - [ ] Verify that the `build_number` is correct
9. - [ ] Verify if the package needs `setuptools`
    
10. - [x] has `wheel`
11. - [x] `pip` in test
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific` or `Noarch`
14. - [ ] Verify that private module are not mentioned on the recipe For example: (_private_module)
15.  - [x] license_file: COPYING.md exists
16. - [x] License: BSD-3-Clause
    - [ ] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

17. - [x] license_family BSD exists
</details>


**Updating the recipe:**

If the recipe needs additional modification the update branch can be modified.

```
git clone -b 5.7.0 git@github.com:AnacondaRecipes/nbformat-feedstock.git
```

