### PR TITLE
nbformat 5.11.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,31 +1,32 @@
 {% set name = "nbformat" %}
-{% set version = "5.10.4" %}
+{% set version = "5.11.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/nbformat-{{ version }}.tar.gz
-  sha256: 322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 7dbaed4a69cae28c2b4d44ab7430a6af4544fb89455023f6f21550be757b60c8
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - jupyter-trust = nbformat.sign:TrustNotebookApp.launch_instance
+  skip: true  # [py<310]
 
 requirements:
   host:
     - python
     - pip
-    - hatchling
+    - hatchling >=1.5
     - hatch-nodejs-version
   run:
     - python
+    - python-fastjsonschema >=2.15
     - jsonschema >=2.6
     - jupyter_core >=4.12,!=5.0.*
-    - python-fastjsonschema >=2.15
     - traitlets >=5.1
 
 test:


### PR DESCRIPTION
nbformat 5.11.0 

**Destination channel:** Defaults

### Links

- [PKG-17063]
- dev_url:        https://github.com/jupyter/nbformat/tree/v5.11.0
- conda_forge:    https://github.com/conda-forge/nbformat-feedstock
- pypi:           https://pypi.org/project/nbformat/5.11.0
- pypi inspector: https://inspector.pypi.io/project/nbformat/5.11.0

### Explanation of changes:

- new version number


[PKG-17063]: https://anaconda.atlassian.net/browse/PKG-17063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ